### PR TITLE
fix(PathElement): fixed build issue with swift 4.2 

### DIFF
--- a/BezierPathLength.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BezierPathLength.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/PathElement.swift
+++ b/Source/PathElement.swift
@@ -49,7 +49,7 @@ extension CGPath {
 
 	typealias PathApplier = @convention(block) (UnsafePointer<CGPathElement>) -> Void
 
-	func apply(with applier: PathApplier) {
+	func apply(with applier: @escaping PathApplier) {
 
 		let callback: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CGPathElement>) -> Void = { (info, element) in
 


### PR DESCRIPTION
fix(PathElement): fixed build issue with swift 4.2 as now @noescape is default, added @escape to PathApplier