### PR TITLE
Update PathElement.swift

### DIFF
--- a/Source/PathElement.swift
+++ b/Source/PathElement.swift
@@ -49,7 +49,7 @@ extension CGPath {
 
 	typealias PathApplier = @convention(block) (UnsafePointer<CGPathElement>) -> Void
 
-	func apply(with applier: PathApplier) {
+	func apply(with applier:@escaping PathApplier) {
 
 		let callback: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CGPathElement>) -> Void = { (info, element) in
 


### PR DESCRIPTION
Fixed compiler error: "Converting non-escaping value to 'T' may allow it to escape"